### PR TITLE
Unify how commands are run

### DIFF
--- a/mcmd/__main__.py
+++ b/mcmd/__main__.py
@@ -4,9 +4,7 @@ import sys
 
 from mcmd import io
 from mcmd.arguments import parse_args, print_help, is_intermediate_subcommand
-from mcmd.commands.run import run
 from mcmd.config.loader import load_config
-from mcmd.executor import execute
 from mcmd.io import set_debug
 from mcmd.logging import set_level
 
@@ -27,10 +25,7 @@ def start(argv):
     setattr(args, 'arg_string', ' '.join(argv[1:]))
     set_log_level(args)
 
-    if args.command == 'run':
-        run(args)
-    else:
-        execute(args)
+    args.func(args)
 
     return 0
 

--- a/mcmd/arguments.py
+++ b/mcmd/arguments.py
@@ -3,6 +3,7 @@ import sys
 
 from mcmd.commands.add import arguments as add_args
 from mcmd.commands.config import arguments as config_args
+from mcmd.commands.delete import arguments as delete_args
 from mcmd.commands.disable import arguments as disable_args
 from mcmd.commands.enable import arguments as enable_args
 from mcmd.commands.give import arguments as give_args
@@ -12,7 +13,6 @@ from mcmd.commands.make import arguments as make_args
 from mcmd.commands.ping import arguments as ping_args
 from mcmd.commands.run import arguments as run_args
 from mcmd.commands.script import arguments as script_args
-from mcmd.commands.delete import arguments as delete_args
 from mcmd.commands.set import arguments as set_args
 
 _parser = None
@@ -75,10 +75,10 @@ def print_help():
 def is_intermediate_subcommand(args):
     """
     Some commands have nested subcommands. These intermediate commands are not executable and don't have a 'func'
-    property. (The 'run' command is the exception, it doesn't have a 'func' but is executable.)
+    property.
 
     For example:
     > mcmd add user
     Here, 'add' is the intermediate command.
     """
-    return not hasattr(args, 'func') and not args.command == 'run'
+    return not hasattr(args, 'func')

--- a/mcmd/command.py
+++ b/mcmd/command.py
@@ -1,24 +1,24 @@
-import configparser
-
 from mcmd import history, io
 from mcmd.client import auth
 from mcmd.config import config
 from mcmd.utils.errors import McmdError
 
 
-def execute(args, exit_on_error=True):
-    try:
-        _set_authentication(args)
-        args.func(args)
-    except McmdError as e:
-        _handle_error(str(e), args.write_to_history, args.arg_string, exit_on_error)
-    except configparser.Error as e:
-        message = 'Error reading or writing mcmd.properties: %s' % str(e)
-        _handle_error(message, args.write_to_history, args.arg_string, exit_on_error)
-    else:
-        if args.write_to_history:
-            history.write(args.arg_string, success=True)
-        io.succeed()
+def command(func):
+    """Decorator for commands. Handles auxiliary actions: authentication, history and errors."""
+
+    def wrapper(args, exit_on_error=True):
+        try:
+            _set_authentication(args)
+            func(args)
+        except McmdError as e:
+            _handle_error(str(e), args.write_to_history, args.arg_string, exit_on_error)
+        else:
+            if args.write_to_history:
+                history.write(args.arg_string, success=True)
+            io.succeed()
+
+    return wrapper
 
 
 def _set_authentication(args):

--- a/mcmd/commands/add.py
+++ b/mcmd/commands/add.py
@@ -5,9 +5,10 @@ from pathlib import Path
 import mcmd.config.config as config
 from mcmd import io
 from mcmd.client.molgenis_client import post, get, post_files
+from mcmd.command import command
 from mcmd.io import highlight
-from mcmd.utils.file_helpers import get_file_name_from_path, scan_folders_for_files, select_path
 from mcmd.utils.errors import McmdError
+from mcmd.utils.file_helpers import get_file_name_from_path, scan_folders_for_files, select_path
 
 # Store a reference to the parser so that we can show an error message for the custom validation rule
 p_add_theme = None
@@ -118,6 +119,7 @@ def arguments(subparsers):
 # Methods
 # =======
 
+@command
 def add_user(args):
     io.start('Adding user %s' % highlight(args.username))
 
@@ -137,11 +139,13 @@ def add_user(args):
           })
 
 
+@command
 def add_group(args):
     io.start('Adding group %s' % highlight(args.name))
     post(config.api('group'), {'name': args.name.lower(), 'label': args.name})
 
 
+@command
 def add_package(args):
     io.start('Adding package %s' % highlight(args.id))
 
@@ -154,6 +158,7 @@ def add_package(args):
     post(config.api('rest1') + 'sys_md_Package', data)
 
 
+@command
 def add_token(args):
     io.start('Adding token %s for user %s' % (highlight(args.token), highlight(args.user)))
 
@@ -169,6 +174,7 @@ def add_token(args):
     post(config.api('rest1') + 'sys_sec_Token', data)
 
 
+@command
 def add_theme(args):
     """
     add_theme adds a theme to the stylesheet table
@@ -200,6 +206,7 @@ def add_theme(args):
     post_files(files, api)
 
 
+@command
 def add_logo(args):
     """
     add_logo uploads a logo to add to the left top of the menu

--- a/mcmd/commands/config.py
+++ b/mcmd/commands/config.py
@@ -1,5 +1,6 @@
 import mcmd.config.config as config
 from mcmd import io
+from mcmd.command import command
 from mcmd.io import highlight
 from mcmd.utils.errors import McmdError
 
@@ -39,6 +40,7 @@ def arguments(subparsers):
 # Methods
 # =======
 
+@command
 def config_set_host(args):
     if args.url:
         url = args.url
@@ -51,6 +53,7 @@ def config_set_host(args):
     config.set_host(url)
 
 
+@command
 # noinspection PyUnusedLocal
 def config_add_host(args):
     url = _add_host()

--- a/mcmd/commands/delete.py
+++ b/mcmd/commands/delete.py
@@ -4,6 +4,7 @@ Deletes an entityType or data from an entityType.
 import mcmd.config.config as config
 from mcmd import io
 from mcmd.client.molgenis_client import delete, delete_data, ensure_resource_exists, ResourceType
+from mcmd.command import command
 from mcmd.io import highlight
 
 
@@ -42,6 +43,21 @@ def arguments(subparsers):
 # Methods
 # =======
 
+@command
+def delete_all_data(args):
+    ensure_resource_exists(args.entity_type, ResourceType.ENTITY_TYPE)
+    if args.force or (not args.force and io.confirm(
+            'Are you sure you want to remove all data from entity: {}?'.format(args.entity_type))):
+        _delete_all_data(args.entity_type)
+
+
+@command
+def delete_entity(args):
+    ensure_resource_exists(args.entity_type, ResourceType.ENTITY_TYPE)
+    if args.force or (not args.force and io.confirm(
+            'Are you sure you want to remove the complete entity: {}?'.format(args.entity_type))):
+        _delete_entity_type(args.entity_type)
+
 
 def _delete_row(entity, row):
     url = '{}{}'.format(config.api('rest2'), entity)
@@ -57,17 +73,3 @@ def _delete_all_data(entity):
 def _delete_entity_type(entity):
     io.start('Deleting entity {}'.format(highlight(entity)))
     _delete_row('sys_md_EntityType', entity)
-
-
-def delete_all_data(args):
-    ensure_resource_exists(args.entity_type, ResourceType.ENTITY_TYPE)
-    if args.force or (not args.force and io.confirm(
-            'Are you sure you want to remove all data from entity: {}?'.format(args.entity_type))):
-        _delete_all_data(args.entity_type)
-
-
-def delete_entity(args):
-    ensure_resource_exists(args.entity_type, ResourceType.ENTITY_TYPE)
-    if args.force or (not args.force and io.confirm(
-            'Are you sure you want to remove the complete entity: {}?'.format(args.entity_type))):
-        _delete_entity_type(args.entity_type)

--- a/mcmd/commands/disable.py
+++ b/mcmd/commands/disable.py
@@ -1,6 +1,7 @@
 import mcmd.config.config as config
 from mcmd import io
 from mcmd.client.molgenis_client import ResourceType, post, ensure_resource_exists
+from mcmd.command import command
 from mcmd.io import highlight
 
 
@@ -17,7 +18,7 @@ def arguments(subparsers):
 
     p_disable_rls = p_disable_subparsers.add_parser('rls',
                                                     help='Disables row level security on an entity type')
-    p_disable_rls.set_defaults(func=enable_rls,
+    p_disable_rls.set_defaults(func=disable_rls,
                                write_to_history=True)
     p_disable_rls.add_argument('entity',
                                type=str,
@@ -28,7 +29,8 @@ def arguments(subparsers):
 # Methods
 # =======
 
-def enable_rls(args):
+@command
+def disable_rls(args):
     if not io.confirm('Are you sure you want to disable row level security on %s?' % args.entity):
         return
 

--- a/mcmd/commands/enable.py
+++ b/mcmd/commands/enable.py
@@ -1,6 +1,7 @@
 import mcmd.config.config as config
 from mcmd import io
 from mcmd.client.molgenis_client import ResourceType, post, ensure_resource_exists, one_resource_exists
+from mcmd.command import command
 from mcmd.io import highlight
 from mcmd.utils.errors import McmdError
 
@@ -39,6 +40,7 @@ def arguments(subparsers):
 # Methods
 # =======
 
+@command
 def enable_rls(args):
     io.start('Enabling row level security on entity type %s' % highlight(args.entity))
 
@@ -47,6 +49,7 @@ def enable_rls(args):
                                   'rlsEnabled': True})
 
 
+@command
 def enable_theme(args):
     """
     enable_theme enables a bootstrap theme

--- a/mcmd/commands/give.py
+++ b/mcmd/commands/give.py
@@ -7,6 +7,7 @@ principal doesn't exist, the program will terminate.
 from mcmd import io
 from mcmd.client.molgenis_client import grant, PrincipalType, principal_exists, \
     resource_exists, ResourceType, ensure_resource_exists, ensure_principal_exists
+from mcmd.command import command
 from mcmd.io import multi_choice, highlight
 from mcmd.utils.errors import McmdError
 
@@ -61,6 +62,7 @@ _PERMISSION_SYNONYMS = {'view': 'read',
 # Methods
 # =======
 
+@command
 def give(args):
     # Convert synonyms to correct permission type
     if args.permission in _PERMISSION_SYNONYMS:

--- a/mcmd/commands/history.py
+++ b/mcmd/commands/history.py
@@ -1,5 +1,6 @@
 from mcmd import history as hist
 from mcmd import io
+from mcmd.command import command
 from mcmd.logging import get_logger
 
 
@@ -33,6 +34,7 @@ log = get_logger()
 # Methods
 # =======
 
+@command
 def history(args):
     if args.clear:
         io.start('Clearing history')

--- a/mcmd/commands/import_.py
+++ b/mcmd/commands/import_.py
@@ -10,6 +10,7 @@ from mcmd import io
 from mcmd.client import github_client as github
 from mcmd.client.molgenis_client import post_file, get, import_by_url
 from mcmd.config.home import get_issues_folder
+from mcmd.command import command
 from mcmd.io import highlight
 from mcmd.utils.file_helpers import scan_folders_for_files, select_path
 from mcmd.utils.errors import McmdError
@@ -56,6 +57,7 @@ def arguments(subparsers):
 # Methods
 # =======
 
+@command
 def import_(args):
     _validate_args(args)
     _choose_import_method(args)

--- a/mcmd/commands/make.py
+++ b/mcmd/commands/make.py
@@ -1,6 +1,7 @@
 import mcmd.config.config as config
 from mcmd import io
 from mcmd.client.molgenis_client import post, get
+from mcmd.command import command
 from mcmd.io import highlight
 from mcmd.utils.utils import lower_kebab, upper_snake
 from mcmd.utils.errors import McmdError
@@ -27,6 +28,7 @@ def arguments(subparsers):
 # Methods
 # =======
 
+@command
 def make(args):
     io.start('Making user %s a member of role %s' % (highlight(args.user), highlight(args.role.upper())))
 

--- a/mcmd/commands/ping.py
+++ b/mcmd/commands/ping.py
@@ -2,6 +2,7 @@ from colorama import Fore
 
 import mcmd.config.config as config
 from mcmd.client.molgenis_client import get_version
+from mcmd.command import command
 from mcmd.io import highlight
 from mcmd.utils.errors import McmdError
 
@@ -22,6 +23,7 @@ def arguments(subparsers):
 # =======
 
 # noinspection PyUnusedLocal
+@command
 def ping(args):
     host = config.get('host', 'selected')
     user = config.username()

--- a/mcmd/commands/run.py
+++ b/mcmd/commands/run.py
@@ -1,17 +1,18 @@
 from mcmd import arguments as arg_parser
-from mcmd import io
 from mcmd.config.home import get_scripts_folder
-from mcmd.executor import execute
-
+from mcmd.command import command
 
 # =========
 # Arguments
 # =========
+from mcmd.utils.errors import McmdError
+
 
 def arguments(subparsers):
     p_run = subparsers.add_parser('run',
                                   help='Run an mcmd script')
-    p_run.set_defaults(write_to_history=False)
+    p_run.set_defaults(func=run,
+                       write_to_history=False)
     p_run.add_argument('script',
                        type=str,
                        help='The .mcmd script to run')
@@ -24,25 +25,21 @@ def arguments(subparsers):
 # Methods
 # =======
 
+@command
 def run(args):
     script = get_scripts_folder().joinpath(args.script)
 
-    lines = list()
     try:
         with open(script) as file:
             lines = [line.rstrip('\n') for line in file]
     except OSError as e:
-        io.error('Error reading script: %s' % str(e))
+        raise McmdError('Error reading script: {}'.format(str(e)))
 
     exit_on_error = not args.ignore_errors
     for line in lines:
         sub_args = arg_parser.parse_args(line.split(' '))
         setattr(sub_args, 'arg_string', line)
         if sub_args.command == 'run':
-            io.error("Can't use the run command in a script: %s" % line)
-            if exit_on_error:
-                exit(1)
-            else:
-                continue
+            raise McmdError("Can't use the run command in a script: {}".format(line))
 
-        execute(sub_args, exit_on_error)
+        sub_args.func(sub_args, exit_on_error)

--- a/mcmd/commands/script.py
+++ b/mcmd/commands/script.py
@@ -1,5 +1,6 @@
 from mcmd import history, io
 from mcmd.config.home import get_scripts_folder
+from mcmd.command import command
 from mcmd.io import confirm, highlight
 from mcmd.logging import get_logger
 from mcmd.utils.errors import McmdError
@@ -49,6 +50,7 @@ log = get_logger()
 # Methods
 # =======
 
+@command
 def script(args):
     if args.list:
         _list_scripts()

--- a/mcmd/commands/set.py
+++ b/mcmd/commands/set.py
@@ -6,6 +6,7 @@ import json
 import mcmd.config.config as config
 from mcmd import io
 from mcmd.client.molgenis_client import get, put
+from mcmd.command import command
 from mcmd.io import highlight
 from mcmd.utils.errors import McmdError
 
@@ -31,7 +32,7 @@ def arguments(subparsers):
                        type=str,
                        help="The value to set the attribute to")
 
-    p_set.set_defaults(func=set,
+    p_set.set_defaults(func=set_,
                        write_to_history=True)
 
 
@@ -51,6 +52,21 @@ _SETTING_SYNONYMS = {'mail': 'sys_set_MailSettings',
 # =======
 # Methods
 # =======
+
+@command
+def set_(args):
+    """
+    set sets the given setting of the given settings type to the given value
+    :param args: command line arguments containing: the settings type, the setting to set, and the value to set it to
+    :return: None
+    """
+    entity = _get_settings_entity(args.type)
+    io.start(
+        'Updating {} of {} settings to {}'.format(highlight(args.setting), highlight(args.type), highlight(args.value)))
+    row = _get_row_id(entity)
+    url = '{}{}/{}/{}'.format(config.api('rest1'), entity, row, args.setting)
+    put(url, json.dumps(args.value))
+
 
 def _get_settings():
     entity = 'sys_md_EntityType'
@@ -82,17 +98,3 @@ def _get_row_id(entity):
     query = 'attrs=~id'
     settings = _quick_get(entity, query)
     return settings[0]['id']
-
-
-def set(args):
-    """
-    set sets the given setting of the given settings type to the given value
-    :param args: command line arguments containing: the settings type, the setting to set, and the value to set it to
-    :return: None
-    """
-    entity = _get_settings_entity(args.type)
-    io.start(
-        'Updating {} of {} settings to {}'.format(highlight(args.setting), highlight(args.type), highlight(args.value)))
-    row = _get_row_id(entity)
-    url = '{}{}/{}/{}'.format(config.api('rest1'), entity, row, args.setting)
-    put(url, json.dumps(args.value))


### PR DESCRIPTION
- Introduces @command decorator
- Remove the hack for the 'run' command and treat it like the other commands