### PR TITLE
Fix wrong file name in integration test

### DIFF
--- a/tests/integration/commands/test_import.py
+++ b/tests/integration/commands/test_import.py
@@ -83,7 +83,7 @@ def test_import_in_package(session, package):
 
 @pytest.mark.integration
 def test_import_from_path_in_package(session, package):
-    file = get_dataset_folder().joinpath('testautoId_unpackaged.xlsx')
+    file = get_dataset_folder().joinpath('testAutoId_unpackaged.xlsx')
     run_commander('import --from-path {} --in {}'.format(file, package))
 
     result = session.get('{}_testAutoId'.format(package))


### PR DESCRIPTION
This test fails during the nightly tests due to a wrong file name.

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/system tested
- User documentation updated
- Test plan template updated
- [x] Clean commits
- Added Feature/Fix to release notes
