### PR TITLE
feat: set value from file

### DIFF
--- a/mcmd/utils/file_helpers.py
+++ b/mcmd/utils/file_helpers.py
@@ -51,6 +51,18 @@ def select_path(file_map, file_name):
         raise McmdError('No file found for %s' % file_name)
     return file_path
 
+def read_file(file):
+    """
+    read_file reads the file data into string list
+    :param file: file to read from
+    :return: lines in file
+    """
+    try:
+        with open(file) as file:
+            lines = [line.rstrip('\n') for line in file]
+    except OSError as e:
+        raise McmdError('Error reading file: {}'.format(str(e)))
+    return lines
 
 def _choose_file(paths, name):
     """


### PR DESCRIPTION
Add optional --from-file option to set command
If --from-file is set, the passed value is interpreted as file containing the value to be set

Use case: When is installing/deploying a molgenis app/server it is often needed to change the default menu ( adding redirect links for example). The menu ( json ) can be set via the set command ( in theory), however as this can be a very long string that needs a lot of espacing ( \ for each " ) this can be hard to do. This PR add the option to point to a file to use a source for setting the value. When setting the menu a nicely formatted menu.json file can be used to set the menu.

for example
`mcmd set app molgenis_menu menu.json --from-file`

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/system tested
- [ ] User documentation updated
- [ ] Clean commits
- [ ] Added Feature/Fix to release notes
