### PR TITLE
Refactor: use attrs library for classes

### DIFF
--- a/mcmd/molgenis/system.py
+++ b/mcmd/molgenis/system.py
@@ -1,27 +1,33 @@
 """
 Contains bare-bones definitions of System Entity Types of MOLGENIS.
 """
-from typing import NamedTuple, Optional
+from typing import Optional
+
+import attr
 
 
-class User(NamedTuple):
+@attr.s(frozen=True, auto_attribs=True)
+class User:
     id: str
     username: str
 
 
-class Group(NamedTuple):
+@attr.s(frozen=True, auto_attribs=True)
+class Group:
     id: str
     name: str
 
 
-class Role(NamedTuple):
+@attr.s(frozen=True, auto_attribs=True)
+class Role:
     id: str
     name: str
     label: str
-    group: Optional[Group]
+    group: Optional[Group] = None
 
 
-class RoleMembership(NamedTuple):
+@attr.s(frozen=True, auto_attribs=True)
+class RoleMembership:
     id: str
     user: User
     role: Role

--- a/mcmd/script/model/lines.py
+++ b/mcmd/script/model/lines.py
@@ -10,7 +10,7 @@ class Line:
 
 
 @attr.s(frozen=True, auto_attribs=True)
-class ScriptLine:
+class ParsedLine:
     """
     A parsed line contains the line number, original line string and the parsed Statement. A parsed line may have
     dependencies on other lines (through Templates). These are exposed through the dependencies property.

--- a/mcmd/script/model/lines.py
+++ b/mcmd/script/model/lines.py
@@ -1,14 +1,17 @@
-from typing import NamedTuple, Set
+from typing import Set
+
+import attr
 
 from mcmd.script.model.statements import Statement
 
 
-class Line(NamedTuple):
-    number: int
-    string: str
+@attr.s(frozen=True)
+class Line:
+    number: int = attr.ib()
+    string: str = attr.ib()
 
 
-class ParsedLine:
+class ScriptLine:
     """
     A parsed line contains the line number, original line string and the parsed Statement. A parsed line may have
     dependencies on other lines (through Templates). These are exposed through the dependencies property.
@@ -33,14 +36,14 @@ class ParsedLine:
         return self._statement
 
     @property
-    def dependencies(self) -> Set['ParsedLine']:
+    def dependencies(self) -> Set['ScriptLine']:
         return self._dependencies
 
-    def add_dependency(self, line: 'ParsedLine'):
+    def add_dependency(self, line: 'ScriptLine'):
         self._dependencies.add(line)
 
-    def __eq__ (self, other): 
-        if isinstance (other, ParsedLine):
+    def __eq__(self, other):
+        if isinstance(other, ScriptLine):
             if self._raw != other._raw: return False
             if self._number != other._number: return False
             if self._statement != other._statement: return False
@@ -54,4 +57,3 @@ class ParsedLine:
 
     def __hash__(self):
         return hash(self.__key())
-

--- a/mcmd/script/model/lines.py
+++ b/mcmd/script/model/lines.py
@@ -1,5 +1,3 @@
-from typing import Set
-
 import attr
 
 from mcmd.script.model.statements import Statement
@@ -11,49 +9,13 @@ class Line:
     string: str = attr.ib()
 
 
+@attr.s(frozen=True)
 class ScriptLine:
     """
     A parsed line contains the line number, original line string and the parsed Statement. A parsed line may have
     dependencies on other lines (through Templates). These are exposed through the dependencies property.
     """
 
-    def __init__(self, raw_string: str, number: int, statement: Statement):
-        self._raw = raw_string
-        self._number = number
-        self._statement = statement
-        self._dependencies = set()
-
-    @property
-    def raw(self) -> str:
-        return self._raw
-
-    @property
-    def number(self) -> int:
-        return self._number
-
-    @property
-    def statement(self) -> Statement:
-        return self._statement
-
-    @property
-    def dependencies(self) -> Set['ScriptLine']:
-        return self._dependencies
-
-    def add_dependency(self, line: 'ScriptLine'):
-        self._dependencies.add(line)
-
-    def __eq__(self, other):
-        if isinstance(other, ScriptLine):
-            if self._raw != other._raw: return False
-            if self._number != other._number: return False
-            if self._statement != other._statement: return False
-            if self._dependencies != other._dependencies: return False
-            return True
-        else:
-            return False
-
-    def __key(self):
-        return (self._raw, self._number)
-
-    def __hash__(self):
-        return hash(self.__key())
+    raw: str = attr.ib()
+    number: int = attr.ib()
+    statement: Statement = attr.ib()

--- a/mcmd/script/model/lines.py
+++ b/mcmd/script/model/lines.py
@@ -3,19 +3,19 @@ import attr
 from mcmd.script.model.statements import Statement
 
 
-@attr.s(frozen=True)
+@attr.s(frozen=True, auto_attribs=True)
 class Line:
-    number: int = attr.ib()
-    string: str = attr.ib()
+    number: int
+    string: str
 
 
-@attr.s(frozen=True)
+@attr.s(frozen=True, auto_attribs=True)
 class ScriptLine:
     """
     A parsed line contains the line number, original line string and the parsed Statement. A parsed line may have
     dependencies on other lines (through Templates). These are exposed through the dependencies property.
     """
 
-    raw: str = attr.ib()
-    number: int = attr.ib()
-    statement: Statement = attr.ib()
+    raw: str
+    number: int
+    statement: Statement

--- a/mcmd/script/model/script.py
+++ b/mcmd/script/model/script.py
@@ -1,17 +1,17 @@
 from typing import List, Set
 
-from mcmd.script.model.lines import ParsedLine
+from mcmd.script.model.lines import ScriptLine
 
 
 class Script:
-    def __init__(self, lines: List[ParsedLine]):
+    def __init__(self, lines: List[ScriptLine]):
         self._lines = tuple(lines)
 
     @property
     def lines(self):
         return self._lines
 
-    def get_lines_with_dependencies(self, from_line_number: int) -> List[ParsedLine]:
+    def get_lines_with_dependencies(self, from_line_number: int) -> List[ScriptLine]:
         """
         Gets all the lines in the script from a certain line_number and up. If the lines depend on lines before
         line_number, then those lines will be included as well. This is done recursively, so all dependencies are
@@ -29,7 +29,7 @@ class Script:
             total_lines = (lines_subset | dependencies)
             return sorted(total_lines, key=lambda l: l.number)
 
-    def _get_deep_dependencies(self, line: ParsedLine) -> Set[ParsedLine]:
+    def _get_deep_dependencies(self, line: ScriptLine) -> Set[ScriptLine]:
         dependencies = set()
         dependencies.add(line)
         for dependency in line.dependencies:

--- a/mcmd/script/model/script.py
+++ b/mcmd/script/model/script.py
@@ -2,15 +2,15 @@ from typing import List, Set, Dict
 
 import attr
 
-from mcmd.script.model.lines import ScriptLine
+from mcmd.script.model.lines import ParsedLine
 
 
 @attr.s(frozen=True, auto_attribs=True)
 class Script:
-    lines: List[ScriptLine]
-    _dependencies: Dict[ScriptLine, Set[ScriptLine]]
+    lines: List[ParsedLine]
+    _dependencies: Dict[ParsedLine, Set[ParsedLine]]
 
-    def get_lines_with_dependencies(self, from_line_number: int) -> List[ScriptLine]:
+    def get_lines_with_dependencies(self, from_line_number: int) -> List[ParsedLine]:
         """
         Gets all the lines in the script from a certain line_number and up. If the lines depend on lines before
         line_number, then those lines will be included as well. This is done recursively, so all dependencies are
@@ -29,7 +29,7 @@ class Script:
             total_lines = (lines_subset | dependencies)
             return sorted(total_lines, key=lambda l: l.number)
 
-    def _get_deep_dependencies(self, line: ScriptLine) -> Set[ScriptLine]:
+    def _get_deep_dependencies(self, line: ParsedLine) -> Set[ParsedLine]:
         dependencies = set()
         dependencies.add(line)
         for dependency in self._dependencies.get(line, set()):

--- a/mcmd/script/model/script.py
+++ b/mcmd/script/model/script.py
@@ -1,15 +1,14 @@
-from typing import List, Set
+from typing import List, Set, Dict
+
+import attr
 
 from mcmd.script.model.lines import ScriptLine
 
 
+@attr.s(frozen=True)
 class Script:
-    def __init__(self, lines: List[ScriptLine]):
-        self._lines = tuple(lines)
-
-    @property
-    def lines(self):
-        return self._lines
+    lines: List[ScriptLine] = attr.ib()
+    _dependencies: Dict[ScriptLine, Set[ScriptLine]] = attr.ib()
 
     def get_lines_with_dependencies(self, from_line_number: int) -> List[ScriptLine]:
         """
@@ -22,6 +21,7 @@ class Script:
         else:
             lines_subset = {line for line in self.lines if line.number >= from_line_number}
 
+            print(self._dependencies)
             dependencies = set()
             for line in lines_subset:
                 dependencies |= self._get_deep_dependencies(line)
@@ -32,6 +32,6 @@ class Script:
     def _get_deep_dependencies(self, line: ScriptLine) -> Set[ScriptLine]:
         dependencies = set()
         dependencies.add(line)
-        for dependency in line.dependencies:
+        for dependency in self._dependencies.get(line, set()):
             dependencies |= self._get_deep_dependencies(dependency)
         return dependencies

--- a/mcmd/script/model/script.py
+++ b/mcmd/script/model/script.py
@@ -5,10 +5,10 @@ import attr
 from mcmd.script.model.lines import ScriptLine
 
 
-@attr.s(frozen=True)
+@attr.s(frozen=True, auto_attribs=True)
 class Script:
-    lines: List[ScriptLine] = attr.ib()
-    _dependencies: Dict[ScriptLine, Set[ScriptLine]] = attr.ib()
+    lines: List[ScriptLine]
+    _dependencies: Dict[ScriptLine, Set[ScriptLine]]
 
     def get_lines_with_dependencies(self, from_line_number: int) -> List[ScriptLine]:
         """

--- a/mcmd/script/model/statements.py
+++ b/mcmd/script/model/statements.py
@@ -1,15 +1,20 @@
-from abc import abstractmethod, ABC
+from abc import abstractmethod
+from typing import Optional
+
+import attr
 
 from mcmd.script.model.templates import Template
 from mcmd.script.model.types_ import InputType, ValueType
 
 
+@attr.s(frozen=True)
 class Statement:
     """A single or multi-lined statement in a MC script."""
     pass
 
 
-class Assignment(ABC):
+@attr.s(frozen=True)
+class Assignment:
     """
     A statement that assigns a value. Should expose the value's name through the name property.
 
@@ -17,12 +22,10 @@ class Assignment(ABC):
     $input bool is_assigned
     """
 
-    @property
-    @abstractmethod
-    def name(self) -> str:
-        pass
+    name: str = attr.ib()
 
 
+@attr.s(frozen=True)
 class Templatable:
     """
     A statement that contains one or more Templates. Should expose all its Templates' variables through the variables
@@ -34,14 +37,8 @@ class Templatable:
     def variables(self) -> set:
         pass
 
-    def __key(self):
-        return (self.variables)
-    
-    def __hash__ (self):
-        hash(self.__key())
 
-
-
+@attr.s(frozen=True)
 class Value(Statement, Templatable, Assignment):
     """
     A value assignment. Supports text (in the form of a Template), booleans and None values.
@@ -51,57 +48,30 @@ class Value(Statement, Templatable, Assignment):
     $value empty
     """
 
-    def __init__(self, name: str, value=None):
-        self._name = name
-        self.__set_type(value)
-        self._value = value
+    type: ValueType = attr.ib()
+    value = attr.ib()
 
-    def __set_type(self, value):
+    @classmethod
+    def from_untyped_value(cls, name: str, value):
         if value is None:
-            self._type = None
+            type_ = None
         elif isinstance(value, bool):
-            self._type = ValueType.BOOL
+            type_ = ValueType.BOOL
         elif isinstance(value, Template):
-            self._type = ValueType.TEMPLATE
+            type_ = ValueType.TEMPLATE
         else:
             raise ValueError('invalid value type: {}'.format(type(value)))
-
-    @property
-    def name(self) -> str:
-        return self._name
-
-    @property
-    def value(self):
-        return self._value
-
-    @property
-    def type(self) -> ValueType:
-        return self._type
+        return cls(name, type_, value)
 
     @property
     def variables(self) -> set:
-        if self._type == ValueType.TEMPLATE:
-            return self._value.variables
+        if self.type == ValueType.TEMPLATE:
+            return self.value.variables
         else:
             return set()
-    
-    def __eq__ (self, other):
-        if isinstance (other, Value):
-            if self._name != other._name: return False
-            if self._value != other._value: return False
-            if self._type != other._type: return False
-            if self._value.variables != other._value.variables: return False
-            return True
-        else:
-            return False
 
-    def __key(self):
-        return (self._name, self._value, self._type)
 
-    def __hash__(self):
-        return hash(self.__key())
-    
-
+@attr.s(frozen=True)
 class Input(Statement, Templatable, Assignment):
     """
     An input assignment. Doesn't have a value because the inputs are requested from the user at runtime. Supports
@@ -111,51 +81,18 @@ class Input(Statement, Templatable, Assignment):
     $input text type : "text"
     """
 
-    def __init__(self, name: str, type_: InputType, message: Template = None):
-        self._name = name
-        self._type = type_
-        self._message = message
-        self.__set_variables()
-
-    @property
-    def name(self) -> str:
-        return self._name
-
-    @property
-    def type(self) -> InputType:
-        return self._type
-
-    @property
-    def message(self) -> Template:
-        return self._message
+    type: InputType = attr.ib()
+    message: Optional[Template] = attr.ib(default=None)
 
     @property
     def variables(self) -> set:
-        return self._variables
-
-    def __set_variables(self):
-        variables = set()
-        if self._message is not None:
-            variables |= self._message.variables
-        self._variables = variables
-    
-    def __eq__ (self, other): 
-        if isinstance (other, Input):
-            if self._name != other._name: return False
-            if self._type != other._type: return False
-            if self._message != other._message: return False
-            if self._variables != other._variables: return False
-            return True
+        if self.message is not None:
+            return self.message.variables
         else:
-            return False
-    
-    def __key(self):
-        return (self._name, self._type, self._message)
-
-    def __hash__(self):
-        return (self.__key())
+            return set()
 
 
+@attr.s(frozen=True)
 class Wait(Statement, Templatable):
     """
     A wait statement. Shows a message until the user presses enter.
@@ -163,32 +100,14 @@ class Wait(Statement, Templatable):
     $wait : "Get a snack"
     """
 
-    def __init__(self, message: Template):
-        self._message = message
-
-    @property
-    def message(self) -> Template:
-        return self._message
+    message: Template = attr.ib()
 
     @property
     def variables(self) -> set:
-        return self._message.variables
-
-    def __eq__ (self, other):
-        if isinstance (other, Wait):
-            if self._message != other._message: return False
-            if self._message.variables != other._message.variables: return False
-            return True
-        else:
-            return False
-
-    def __key(self):
-        return (self._message)
-
-    def __hash__(self):
-        return (self.__key())
+        return self.message.variables
 
 
+@attr.s(frozen=True)
 class VisibleComment(Statement, Templatable):
     """
     Comments that will be printed to the output.
@@ -196,64 +115,27 @@ class VisibleComment(Statement, Templatable):
     # Creating user {{name}}
     """
 
-    def __init__(self, text: Template):
-        self._text = text
-
-    @property
-    def text(self) -> Template:
-        return self._text
+    text: Template = attr.ib()
 
     @property
     def variables(self) -> set:
-        return self._text.variables
-    
-    def __eq__ (self, other):
-        if isinstance (other, VisibleComment):
-            if self._text != other._text: return False
-            if self._text.variables != other._text.variables: return False 
-            return True
-        else: 
-            return False
-
-    def __key(self):
-        return (self._text)
-
-    def __hash__(self):
-        return (self.__key())
+        return self.text.variables
 
 
+@attr.s(frozen=True)
 class Command(Statement, Templatable):
     """
     A MOLGENIS Commander command.
     """
 
-    def __init__(self, command: Template):
-        self._command = command
-
-    @property
-    def command(self) -> Template:
-        return self._command
+    command: Template = attr.ib()
 
     @property
     def variables(self) -> set:
-        return self._command.variables
-    
-    def __eq__ (self, other):
-        if isinstance (other, Command):
-            if self._command != other._command: return False
-            if self._command.variables != other._command.variables: return False
-            return True
-        else:
-            return False
-    
-    def __key(self):
-        return (self._command)
-
-    def __hash__(self):
-        return (self.__key())
-    
+        return self.command.variables
 
 
+@attr.s(frozen=True)
 class InvisibleComment(Statement):
     """
     Comments that won't be processed in any way.
@@ -261,35 +143,12 @@ class InvisibleComment(Statement):
     // this is a comment
     """
 
-    def __init__(self, comment: str):
-        self._comment = comment
+    comment: str = attr.ib()
 
-    @property
-    def comment(self) -> str:
-        return self._comment
 
-    def __eq__ (self, other):
-        if isinstance (other, InvisibleComment):
-            if self._comment != other._comment: return False
-            return True
-        else:
-            return False
-
-    def __key(self):
-        return (self._comment)
-
-    def __hash__(self):
-        return (self.__key())
-
+@attr.s
 class Empty(Statement):
     """
     An empty line.
     """
     pass
-
-    def __eq__ (self, other):
-        if isinstance (other, Empty): 
-            return True
-        else:
-            return False
-

--- a/mcmd/script/model/statements.py
+++ b/mcmd/script/model/statements.py
@@ -146,7 +146,7 @@ class InvisibleComment(Statement):
     comment: str = attr.ib()
 
 
-@attr.s
+@attr.s(frozen=True)
 class Empty(Statement):
     """
     An empty line.

--- a/mcmd/script/model/statements.py
+++ b/mcmd/script/model/statements.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import Optional
+from typing import Optional, Any
 
 import attr
 
@@ -13,7 +13,7 @@ class Statement:
     pass
 
 
-@attr.s(frozen=True)
+@attr.s(frozen=True, auto_attribs=True)
 class Assignment:
     """
     A statement that assigns a value. Should expose the value's name through the name property.
@@ -22,7 +22,7 @@ class Assignment:
     $input bool is_assigned
     """
 
-    name: str = attr.ib()
+    name: str
 
 
 @attr.s(frozen=True)
@@ -38,7 +38,7 @@ class Templatable:
         pass
 
 
-@attr.s(frozen=True)
+@attr.s(frozen=True, auto_attribs=True)
 class Value(Statement, Templatable, Assignment):
     """
     A value assignment. Supports text (in the form of a Template), booleans and None values.
@@ -48,8 +48,8 @@ class Value(Statement, Templatable, Assignment):
     $value empty
     """
 
-    type: ValueType = attr.ib()
-    value = attr.ib()
+    type: ValueType
+    value: Any
 
     @classmethod
     def from_untyped_value(cls, name: str, value):
@@ -71,7 +71,7 @@ class Value(Statement, Templatable, Assignment):
             return set()
 
 
-@attr.s(frozen=True)
+@attr.s(frozen=True, auto_attribs=True)
 class Input(Statement, Templatable, Assignment):
     """
     An input assignment. Doesn't have a value because the inputs are requested from the user at runtime. Supports
@@ -81,8 +81,8 @@ class Input(Statement, Templatable, Assignment):
     $input text type : "text"
     """
 
-    type: InputType = attr.ib()
-    message: Optional[Template] = attr.ib(default=None)
+    type: InputType
+    message: Optional[Template] = None
 
     @property
     def variables(self) -> frozenset:
@@ -92,7 +92,7 @@ class Input(Statement, Templatable, Assignment):
             return frozenset()
 
 
-@attr.s(frozen=True)
+@attr.s(frozen=True, auto_attribs=True)
 class Wait(Statement, Templatable):
     """
     A wait statement. Shows a message until the user presses enter.
@@ -100,14 +100,14 @@ class Wait(Statement, Templatable):
     $wait : "Get a snack"
     """
 
-    message: Template = attr.ib()
+    message: Template
 
     @property
     def variables(self) -> frozenset:
         return self.message.variables
 
 
-@attr.s(frozen=True)
+@attr.s(frozen=True, auto_attribs=True)
 class VisibleComment(Statement, Templatable):
     """
     Comments that will be printed to the output.
@@ -115,27 +115,27 @@ class VisibleComment(Statement, Templatable):
     # Creating user {{name}}
     """
 
-    text: Template = attr.ib()
+    text: Template
 
     @property
     def variables(self) -> frozenset:
         return self.text.variables
 
 
-@attr.s(frozen=True)
+@attr.s(frozen=True, auto_attribs=True)
 class Command(Statement, Templatable):
     """
     A MOLGENIS Commander command.
     """
 
-    command: Template = attr.ib()
+    command: Template
 
     @property
     def variables(self) -> frozenset:
         return self.command.variables
 
 
-@attr.s(frozen=True)
+@attr.s(frozen=True, auto_attribs=True)
 class InvisibleComment(Statement):
     """
     Comments that won't be processed in any way.
@@ -143,7 +143,7 @@ class InvisibleComment(Statement):
     // this is a comment
     """
 
-    comment: str = attr.ib()
+    comment: str
 
 
 @attr.s(frozen=True)

--- a/mcmd/script/model/statements.py
+++ b/mcmd/script/model/statements.py
@@ -34,7 +34,7 @@ class Templatable:
 
     @property
     @abstractmethod
-    def variables(self) -> set:
+    def variables(self) -> frozenset:
         pass
 
 
@@ -85,11 +85,11 @@ class Input(Statement, Templatable, Assignment):
     message: Optional[Template] = attr.ib(default=None)
 
     @property
-    def variables(self) -> set:
+    def variables(self) -> frozenset:
         if self.message is not None:
             return self.message.variables
         else:
-            return set()
+            return frozenset()
 
 
 @attr.s(frozen=True)
@@ -103,7 +103,7 @@ class Wait(Statement, Templatable):
     message: Template = attr.ib()
 
     @property
-    def variables(self) -> set:
+    def variables(self) -> frozenset:
         return self.message.variables
 
 
@@ -118,7 +118,7 @@ class VisibleComment(Statement, Templatable):
     text: Template = attr.ib()
 
     @property
-    def variables(self) -> set:
+    def variables(self) -> frozenset:
         return self.text.variables
 
 
@@ -131,7 +131,7 @@ class Command(Statement, Templatable):
     command: Template = attr.ib()
 
     @property
-    def variables(self) -> set:
+    def variables(self) -> frozenset:
         return self.command.variables
 
 

--- a/mcmd/script/model/templates.py
+++ b/mcmd/script/model/templates.py
@@ -18,11 +18,11 @@ class Template:
     variables: FrozenSet[str] = attr.ib(init=False)
 
     @_template.default
-    def __set_template(self):
+    def __set_template(self):  # NOSONAR method is not unused
         return _env.from_string(self.string)
 
     @variables.default
-    def __set_variables(self) -> frozenset:
+    def __set_variables(self) -> frozenset:  # NOSONAR method is not unused
         parsed_content = _env.parse(self.string)
         return frozenset(meta.find_undeclared_variables(parsed_content))
 

--- a/mcmd/script/model/templates.py
+++ b/mcmd/script/model/templates.py
@@ -1,41 +1,29 @@
+from typing import FrozenSet
+
+import attr
 from jinja2 import Environment, meta
 
 _env = Environment(autoescape=False)
 
 
+@attr.s(frozen=True)
 class Template:
     """
     A container for a Jinja2 template. Exposes the variables found in the template through the variables property.
     """
 
-    def __init__(self, template_str: str):
-        self._string = template_str
-        self._template = _env.from_string(template_str)
+    string: str = attr.ib()
+    _template = attr.ib(init=False, eq=False)
+    variables: FrozenSet[str] = attr.ib(init=False)
 
-        parsed_content = _env.parse(template_str)
-        self._variables = meta.find_undeclared_variables(parsed_content)
+    @_template.default
+    def __set_template(self):
+        return _env.from_string(self.string)
 
-    @property
-    def variables(self) -> set:
-        return self._variables
-
-    @property
-    def string(self) -> str:
-        return self._string
+    @variables.default
+    def __set_variables(self) -> frozenset:
+        parsed_content = _env.parse(self.string)
+        return frozenset(meta.find_undeclared_variables(parsed_content))
 
     def render(self, values: dict) -> str:
         return self._template.render(values)
-
-    def __eq__ (self, other):
-        if isinstance (other, Template): 
-            if self._variables != other._variables: return False
-            if self._string != other._string: return False
-            return True
-        else:
-            return False
-    
-    def __key(self):
-        return (self._string)
-
-    def __hash__(self):
-        return hash(self.__key())

--- a/mcmd/script/model/templates.py
+++ b/mcmd/script/model/templates.py
@@ -1,19 +1,20 @@
 from typing import FrozenSet
 
 import attr
+import jinja2
 from jinja2 import Environment, meta
 
 _env = Environment(autoescape=False)
 
 
-@attr.s(frozen=True)
+@attr.s(frozen=True, auto_attribs=True)
 class Template:
     """
     A container for a Jinja2 template. Exposes the variables found in the template through the variables property.
     """
 
-    string: str = attr.ib()
-    _template = attr.ib(init=False, eq=False)
+    string: str
+    _template: jinja2.Template = attr.ib(init=False, eq=False)
     variables: FrozenSet[str] = attr.ib(init=False)
 
     @_template.default

--- a/mcmd/script/options.py
+++ b/mcmd/script/options.py
@@ -1,9 +1,10 @@
-from typing import NamedTuple
+import attr
 
 
-class ScriptOptions(NamedTuple):
-    arguments: dict
-    dry_run: bool
-    start_at: int
-    log_comments: bool
-    exit_on_error: bool
+@attr.s(frozen=True, auto_attribs=True)
+class ScriptOptions:
+    arguments: dict = attr.Factory(dict)
+    dry_run: bool = False
+    start_at: int = 1
+    log_comments: bool = True
+    exit_on_error: bool = True

--- a/mcmd/script/parser/_parse_state.py
+++ b/mcmd/script/parser/_parse_state.py
@@ -6,10 +6,10 @@ from mcmd.script.model.lines import ScriptLine, Line
 from mcmd.script.parser.errors import ScriptValidationError
 
 
-@attr.s
+@attr.s(auto_attribs=True)
 class _ParseState:
-    lines: List[ScriptLine] = attr.ib(default=attr.Factory(list))
-    raw_lines: List[str] = attr.ib(default=attr.Factory(list))
-    combined_lines: List[Line] = attr.ib(default=attr.Factory(list))
-    errors: List[ScriptValidationError] = attr.ib(default=attr.Factory(list))
-    dependencies: Dict[ScriptLine, Set[ScriptLine]] = attr.ib(default=attr.Factory(dict))
+    lines: List[ScriptLine] = attr.Factory(list)
+    raw_lines: List[str] = attr.Factory(list)
+    combined_lines: List[Line] = attr.Factory(list)
+    errors: List[ScriptValidationError] = attr.Factory(list)
+    dependencies: Dict[ScriptLine, Set[ScriptLine]] = attr.Factory(dict)

--- a/mcmd/script/parser/_parse_state.py
+++ b/mcmd/script/parser/_parse_state.py
@@ -1,13 +1,13 @@
 from typing import List, Dict
 
-from mcmd.script.model.lines import ParsedLine, Line
+from mcmd.script.model.lines import ScriptLine, Line
 from mcmd.script.parser.errors import ScriptValidationError
 
 
 class _ParseState:
 
     def __init__(self):
-        self.lines: List[ParsedLine] = list()
+        self.lines: List[ScriptLine] = list()
         self.raw_lines: List[str] = list()
         self.combined_lines: List[Line] = list()
         self.required_args: Dict[int, str] = dict()

--- a/mcmd/script/parser/_parse_state.py
+++ b/mcmd/script/parser/_parse_state.py
@@ -1,14 +1,15 @@
-from typing import List, Dict
+from typing import List, Dict, Set
+
+import attr
 
 from mcmd.script.model.lines import ScriptLine, Line
 from mcmd.script.parser.errors import ScriptValidationError
 
 
+@attr.s
 class _ParseState:
-
-    def __init__(self):
-        self.lines: List[ScriptLine] = list()
-        self.raw_lines: List[str] = list()
-        self.combined_lines: List[Line] = list()
-        self.required_args: Dict[int, str] = dict()
-        self.errors: List[ScriptValidationError] = list()
+    lines: List[ScriptLine] = attr.ib(default=attr.Factory(list))
+    raw_lines: List[str] = attr.ib(default=attr.Factory(list))
+    combined_lines: List[Line] = attr.ib(default=attr.Factory(list))
+    errors: List[ScriptValidationError] = attr.ib(default=attr.Factory(list))
+    dependencies: Dict[ScriptLine, Set[ScriptLine]] = attr.ib(default=attr.Factory(dict))

--- a/mcmd/script/parser/_parse_state.py
+++ b/mcmd/script/parser/_parse_state.py
@@ -2,14 +2,14 @@ from typing import List, Dict, Set
 
 import attr
 
-from mcmd.script.model.lines import ScriptLine, Line
+from mcmd.script.model.lines import ParsedLine, Line
 from mcmd.script.parser.errors import ScriptValidationError
 
 
 @attr.s(auto_attribs=True)
 class _ParseState:
-    lines: List[ScriptLine] = attr.Factory(list)
+    lines: List[ParsedLine] = attr.Factory(list)
     raw_lines: List[str] = attr.Factory(list)
     combined_lines: List[Line] = attr.Factory(list)
     errors: List[ScriptValidationError] = attr.Factory(list)
-    dependencies: Dict[ScriptLine, Set[ScriptLine]] = attr.Factory(dict)
+    dependencies: Dict[ParsedLine, Set[ParsedLine]] = attr.Factory(dict)

--- a/mcmd/script/parser/dependency_resolver.py
+++ b/mcmd/script/parser/dependency_resolver.py
@@ -1,4 +1,4 @@
-from mcmd.script.model.lines import ScriptLine
+from mcmd.script.model.lines import ParsedLine
 from mcmd.script.model.statements import Templatable, Assignment
 from mcmd.script.parser._parse_state import _ParseState
 from mcmd.script.parser.errors import ReassignmentError, ForwardReferenceError, UnknownReferenceError, \
@@ -26,7 +26,7 @@ def resolve(state: _ParseState):
             _set_dependencies(declarations_by_name, line, statement.variables, state)
 
 
-def _set_dependencies(declarations_by_name: dict, line: ScriptLine, variables: frozenset, state: _ParseState):
+def _set_dependencies(declarations_by_name: dict, line: ParsedLine, variables: frozenset, state: _ParseState):
     for var in variables:
         if var not in declarations_by_name:
             state.errors.append(UnknownReferenceError(line, var))

--- a/mcmd/script/parser/dependency_resolver.py
+++ b/mcmd/script/parser/dependency_resolver.py
@@ -26,7 +26,7 @@ def resolve(state: _ParseState):
             _set_dependencies(declarations_by_name, line, statement.variables, state)
 
 
-def _set_dependencies(declarations_by_name: dict, line: ScriptLine, variables: set, state: _ParseState):
+def _set_dependencies(declarations_by_name: dict, line: ScriptLine, variables: frozenset, state: _ParseState):
     for var in variables:
         if var not in declarations_by_name:
             state.errors.append(UnknownReferenceError(line, var))

--- a/mcmd/script/parser/dependency_resolver.py
+++ b/mcmd/script/parser/dependency_resolver.py
@@ -23,12 +23,11 @@ def resolve(state: _ParseState):
     for line in state.lines:
         statement = line.statement
         if isinstance(statement, Templatable):
-            _add_dependencies(declarations_by_name, line, statement.variables, state)
+            _set_dependencies(declarations_by_name, line, statement.variables, state)
 
 
-def _add_dependencies(declarations_by_name: dict, line: ScriptLine, variables: set, state: _ParseState):
+def _set_dependencies(declarations_by_name: dict, line: ScriptLine, variables: set, state: _ParseState):
     for var in variables:
-
         if var not in declarations_by_name:
             state.errors.append(UnknownReferenceError(line, var))
         else:
@@ -39,4 +38,7 @@ def _add_dependencies(declarations_by_name: dict, line: ScriptLine, variables: s
             elif dependency.number >= line.number:
                 state.errors.append(ForwardReferenceError(var, line, dependency))
             else:
-                line.add_dependency(declarations_by_name[var])
+                if line not in state.dependencies:
+                    state.dependencies[line] = {declarations_by_name[var]}
+                else:
+                    state.dependencies[line].add(declarations_by_name[var])

--- a/mcmd/script/parser/dependency_resolver.py
+++ b/mcmd/script/parser/dependency_resolver.py
@@ -1,4 +1,4 @@
-from mcmd.script.model.lines import ParsedLine
+from mcmd.script.model.lines import ScriptLine
 from mcmd.script.model.statements import Templatable, Assignment
 from mcmd.script.parser._parse_state import _ParseState
 from mcmd.script.parser.errors import ReassignmentError, ForwardReferenceError, UnknownReferenceError, \
@@ -26,7 +26,7 @@ def resolve(state: _ParseState):
             _add_dependencies(declarations_by_name, line, statement.variables, state)
 
 
-def _add_dependencies(declarations_by_name: dict, line: ParsedLine, variables: set, state: _ParseState):
+def _add_dependencies(declarations_by_name: dict, line: ScriptLine, variables: set, state: _ParseState):
     for var in variables:
 
         if var not in declarations_by_name:

--- a/mcmd/script/parser/errors.py
+++ b/mcmd/script/parser/errors.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import List
 
-from mcmd.script.model.lines import Line, ScriptLine
+from mcmd.script.model.lines import Line, ParsedLine
 
 
 class ScriptValidationError(ABC, Exception):
@@ -55,7 +55,7 @@ class ReassignmentError(ScriptValidationError):
     Raised when a value has already been assigned in an earlier line.
     """
 
-    def __init__(self, name: str, source: ScriptLine, other: ScriptLine):
+    def __init__(self, name: str, source: ParsedLine, other: ParsedLine):
         super().__init__(line_number=source.number)
         self._name = name
         self._source = source
@@ -75,7 +75,7 @@ class ForwardReferenceError(ScriptValidationError):
     Raised when a Template references a value that is assigned at a later line.
     """
 
-    def __init__(self, name: str, source: ScriptLine, referred: ScriptLine):
+    def __init__(self, name: str, source: ParsedLine, referred: ParsedLine):
         super().__init__(line_number=source.number)
         self._name = name
         self._source = source
@@ -97,7 +97,7 @@ class UnknownReferenceError(ScriptValidationError):
     Raised when a Template references a value that is not assigned in the script.
     """
 
-    def __init__(self, source: ScriptLine, reference: str):
+    def __init__(self, source: ParsedLine, reference: str):
         super().__init__(line_number=source.number)
         self._source = source
         self._reference = reference
@@ -117,7 +117,7 @@ class RecursiveReferenceError(ScriptValidationError):
     $value name = "{{name}}"
     """
 
-    def __init__(self, source: ScriptLine, reference: str):
+    def __init__(self, source: ParsedLine, reference: str):
         super().__init__(line_number=source.number)
         self._source = source
         self._reference = reference

--- a/mcmd/script/parser/errors.py
+++ b/mcmd/script/parser/errors.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import List
 
-from mcmd.script.model.lines import Line, ParsedLine
+from mcmd.script.model.lines import Line, ScriptLine
 
 
 class ScriptValidationError(ABC, Exception):
@@ -55,7 +55,7 @@ class ReassignmentError(ScriptValidationError):
     Raised when a value has already been assigned in an earlier line.
     """
 
-    def __init__(self, name: str, source: ParsedLine, other: ParsedLine):
+    def __init__(self, name: str, source: ScriptLine, other: ScriptLine):
         super().__init__(line_number=source.number)
         self._name = name
         self._source = source
@@ -75,7 +75,7 @@ class ForwardReferenceError(ScriptValidationError):
     Raised when a Template references a value that is assigned at a later line.
     """
 
-    def __init__(self, name: str, source: ParsedLine, referred: ParsedLine):
+    def __init__(self, name: str, source: ScriptLine, referred: ScriptLine):
         super().__init__(line_number=source.number)
         self._name = name
         self._source = source
@@ -97,7 +97,7 @@ class UnknownReferenceError(ScriptValidationError):
     Raised when a Template references a value that is not assigned in the script.
     """
 
-    def __init__(self, source: ParsedLine, reference: str):
+    def __init__(self, source: ScriptLine, reference: str):
         super().__init__(line_number=source.number)
         self._source = source
         self._reference = reference
@@ -117,7 +117,7 @@ class RecursiveReferenceError(ScriptValidationError):
     $value name = "{{name}}"
     """
 
-    def __init__(self, source: ParsedLine, reference: str):
+    def __init__(self, source: ScriptLine, reference: str):
         super().__init__(line_number=source.number)
         self._source = source
         self._reference = reference

--- a/mcmd/script/parser/line_parser.py
+++ b/mcmd/script/parser/line_parser.py
@@ -34,7 +34,7 @@ def _value_declaration():
     yield whitespace
     name = yield _value_name
     value = yield _assignment.optional()
-    return Value(name=name, value=value)
+    return Value.from_untyped_value(name=name, value=value)
 
 
 # $input type name [: "message"]
@@ -49,7 +49,7 @@ def _input_declaration():
     message = yield _message.optional()
 
     return Input(name=name,
-                 type_=type_,
+                 type=type_,
                  message=message)
 
 

--- a/mcmd/script/parser/script_parser.py
+++ b/mcmd/script/parser/script_parser.py
@@ -29,7 +29,7 @@ def parse(str_lines: List[str]) -> Script:
     if len(state.errors) > 0:
         raise InvalidScriptError(state.errors)
     else:
-        return Script(lines=state.lines)
+        return Script(lines=state.lines, dependencies=state.dependencies)
 
 
 def _parse_lines(state: _ParseState):
@@ -39,4 +39,4 @@ def _parse_lines(state: _ParseState):
         except ScriptSyntaxError as e:
             state.errors.append(e)
         else:
-            state.lines.append(ScriptLine(raw_string=line.string, number=line.number, statement=statement))
+            state.lines.append(ScriptLine(raw=line.string, number=line.number, statement=statement))

--- a/mcmd/script/parser/script_parser.py
+++ b/mcmd/script/parser/script_parser.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from mcmd.script.model.lines import ParsedLine
+from mcmd.script.model.lines import ScriptLine
 from mcmd.script.model.script import Script
 from mcmd.script.parser import dependency_resolver, line_parser, line_combiner
 from mcmd.script.parser._parse_state import _ParseState
@@ -39,4 +39,4 @@ def _parse_lines(state: _ParseState):
         except ScriptSyntaxError as e:
             state.errors.append(e)
         else:
-            state.lines.append(ParsedLine(raw_string=line.string, number=line.number, statement=statement))
+            state.lines.append(ScriptLine(raw_string=line.string, number=line.number, statement=statement))

--- a/mcmd/script/parser/script_parser.py
+++ b/mcmd/script/parser/script_parser.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from mcmd.script.model.lines import ScriptLine
+from mcmd.script.model.lines import ParsedLine
 from mcmd.script.model.script import Script
 from mcmd.script.parser import dependency_resolver, line_parser, line_combiner
 from mcmd.script.parser._parse_state import _ParseState
@@ -39,4 +39,4 @@ def _parse_lines(state: _ParseState):
         except ScriptSyntaxError as e:
             state.errors.append(e)
         else:
-            state.lines.append(ScriptLine(raw=line.string, number=line.number, statement=statement))
+            state.lines.append(ParsedLine(raw=line.string, number=line.number, statement=statement))

--- a/mcmd/script/script_runner.py
+++ b/mcmd/script/script_runner.py
@@ -1,6 +1,8 @@
 import shlex
 import sys
-from typing import NamedTuple, List
+from typing import List
+
+import attr
 
 from mcmd.args import parser as arg_parser
 from mcmd.args.errors import ArgumentSyntaxError
@@ -18,10 +20,11 @@ from mcmd.script.options import ScriptOptions
 log = get_logger()
 
 
-class _ScriptExecutionState(NamedTuple):
+@attr.s(auto_attribs=True)
+class _ScriptExecutionState:
     script: Script
     options: ScriptOptions
-    values: dict
+    values: dict = attr.Factory(dict)
 
 
 def run(script: Script, options: ScriptOptions):

--- a/mcmd/script/script_runner.py
+++ b/mcmd/script/script_runner.py
@@ -8,7 +8,7 @@ from mcmd.core.errors import McmdError, ScriptError
 from mcmd.io import io, ask
 from mcmd.io.io import bold, dim
 from mcmd.io.logging import get_logger
-from mcmd.script.model.lines import ParsedLine
+from mcmd.script.model.lines import ScriptLine
 from mcmd.script.model.script import Script
 from mcmd.script.model.statements import Value, Input, Wait, VisibleComment, Command, InvisibleComment, \
     Empty
@@ -36,7 +36,7 @@ def run(script: Script, options: ScriptOptions):
     _process_lines(lines, state)
 
 
-def _validate_required_args(lines: List[ParsedLine], args: dict):
+def _validate_required_args(lines: List[ScriptLine], args: dict):
     missing_args = list()
     for line in lines:
         statement = line.statement
@@ -47,7 +47,7 @@ def _validate_required_args(lines: List[ParsedLine], args: dict):
         raise McmdError('Missing required argument(s): {}'.format(', '.join(missing_args)))
 
 
-def _process_lines(lines: List[ParsedLine], state: _ScriptExecutionState):
+def _process_lines(lines: List[ScriptLine], state: _ScriptExecutionState):
     for line in lines:
         try:
             _process_line(line, state)
@@ -55,7 +55,7 @@ def _process_lines(lines: List[ParsedLine], state: _ScriptExecutionState):
             _handle_error(error, line_number=line.number, state=state)
 
 
-def _process_line(line: ParsedLine, state: _ScriptExecutionState):
+def _process_line(line: ScriptLine, state: _ScriptExecutionState):
     statement = line.statement
 
     if isinstance(statement, Value):

--- a/mcmd/script/script_runner.py
+++ b/mcmd/script/script_runner.py
@@ -10,7 +10,7 @@ from mcmd.core.errors import McmdError, ScriptError
 from mcmd.io import io, ask
 from mcmd.io.io import bold, dim
 from mcmd.io.logging import get_logger
-from mcmd.script.model.lines import ScriptLine
+from mcmd.script.model.lines import ParsedLine
 from mcmd.script.model.script import Script
 from mcmd.script.model.statements import Value, Input, Wait, VisibleComment, Command, InvisibleComment, \
     Empty
@@ -39,7 +39,7 @@ def run(script: Script, options: ScriptOptions):
     _process_lines(lines, state)
 
 
-def _validate_required_args(lines: List[ScriptLine], args: dict):
+def _validate_required_args(lines: List[ParsedLine], args: dict):
     missing_args = list()
     for line in lines:
         statement = line.statement
@@ -50,7 +50,7 @@ def _validate_required_args(lines: List[ScriptLine], args: dict):
         raise McmdError('Missing required argument(s): {}'.format(', '.join(missing_args)))
 
 
-def _process_lines(lines: List[ScriptLine], state: _ScriptExecutionState):
+def _process_lines(lines: List[ParsedLine], state: _ScriptExecutionState):
     for line in lines:
         try:
             _process_line(line, state)
@@ -58,7 +58,7 @@ def _process_lines(lines: List[ScriptLine], state: _ScriptExecutionState):
             _handle_error(error, line_number=line.number, state=state)
 
 
-def _process_line(line: ScriptLine, state: _ScriptExecutionState):
+def _process_line(line: ParsedLine, state: _ScriptExecutionState):
     statement = line.statement
 
     if isinstance(statement, Value):

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     },
     install_requires=['requests==2.21.0', 'rainbow_logging_handler==2.2.2', 'halo==0.0.28',
                       'polling==0.3.0', 'PyGithub==1.43.3', 'colorama==0.3.9', 'ruamel.yaml==0.15.81',
-                      'questionary==1.3.0', 'parsy==1.3.0', 'Jinja2==2.11.2'],
+                      'questionary==1.3.0', 'parsy==1.3.0', 'Jinja2==2.11.2', 'attrs==19.3.0'],
     setup_requires=['pytest-runner'],
     tests_require=['pytest', 'testfixtures', 'molgenis-py-client==1.0.0']
 )

--- a/tests/unit/script/line_parser_test.py
+++ b/tests/unit/script/line_parser_test.py
@@ -3,11 +3,11 @@ import unittest
 import pytest
 from parsy import ParseError
 
-# noinspection PyProtectedMember
-from mcmd.script.parser.line_parser import _parse_line
 from mcmd.script.model.statements import Value, Input, Wait, VisibleComment, Command, InvisibleComment, \
     Empty
 from mcmd.script.model.types_ import InputType
+# noinspection PyProtectedMember
+from mcmd.script.parser.line_parser import _parse_line
 
 
 @pytest.mark.unit

--- a/tests/unit/script/script_parser_test.py
+++ b/tests/unit/script/script_parser_test.py
@@ -2,7 +2,7 @@ import unittest
 
 import pytest
 
-from mcmd.script.model.lines import ParsedLine, Line
+from mcmd.script.model.lines import ScriptLine, Line
 from mcmd.script.model.statements import VisibleComment, InvisibleComment, Value, Command, Input, Empty, Wait
 from mcmd.script.model.templates import Template
 from mcmd.script.model.types_ import InputType
@@ -30,15 +30,15 @@ class ScriptParserTest(unittest.TestCase):
         ]
 
         expected_lines = [
-            ParsedLine("# add user henk", 1, VisibleComment(Template("add user henk"))),
-            ParsedLine("// adding user henk", 2, InvisibleComment("adding user henk")),
-            ParsedLine("$value name='henk'", 3, Value.from_untyped_value("name", Template("henk"))),
-            ParsedLine("add user {{name}} --is-superuser --is-active", 4,
+            ScriptLine("# add user henk", 1, VisibleComment(Template("add user henk"))),
+            ScriptLine("// adding user henk", 2, InvisibleComment("adding user henk")),
+            ScriptLine("$value name='henk'", 3, Value.from_untyped_value("name", Template("henk"))),
+            ScriptLine("add user {{name}} --is-superuser --is-active", 4,
                        Command(Template('add user {{name}} --is-superuser --is-active'))),
-            ParsedLine("$input text value: 'default value'", 5,
+            ScriptLine("$input text value: 'default value'", 5,
                        Input("value", InputType.TEXT, Template('default value'))),
-            ParsedLine("$wait Wait and relax", 6, Wait(Template("Wait and relax"))),
-            ParsedLine("", 7, Empty())
+            ScriptLine("$wait Wait and relax", 6, Wait(Template("Wait and relax"))),
+            ScriptLine("", 7, Empty())
         ]
 
         script_parser._parse_lines(state)

--- a/tests/unit/script/script_parser_test.py
+++ b/tests/unit/script/script_parser_test.py
@@ -32,7 +32,7 @@ class ScriptParserTest(unittest.TestCase):
         expected_lines = [
             ParsedLine("# add user henk", 1, VisibleComment(Template("add user henk"))),
             ParsedLine("// adding user henk", 2, InvisibleComment("adding user henk")),
-            ParsedLine("$value name='henk'", 3, Value("name", Template("henk"))),
+            ParsedLine("$value name='henk'", 3, Value.from_untyped_value("name", Template("henk"))),
             ParsedLine("add user {{name}} --is-superuser --is-active", 4,
                        Command(Template('add user {{name}} --is-superuser --is-active'))),
             ParsedLine("$input text value: 'default value'", 5,

--- a/tests/unit/script/script_parser_test.py
+++ b/tests/unit/script/script_parser_test.py
@@ -2,7 +2,7 @@ import unittest
 
 import pytest
 
-from mcmd.script.model.lines import ScriptLine, Line
+from mcmd.script.model.lines import ParsedLine, Line
 from mcmd.script.model.statements import VisibleComment, InvisibleComment, Value, Command, Input, Empty, Wait
 from mcmd.script.model.templates import Template
 from mcmd.script.model.types_ import InputType
@@ -30,15 +30,15 @@ class ScriptParserTest(unittest.TestCase):
         ]
 
         expected_lines = [
-            ScriptLine("# add user henk", 1, VisibleComment(Template("add user henk"))),
-            ScriptLine("// adding user henk", 2, InvisibleComment("adding user henk")),
-            ScriptLine("$value name='henk'", 3, Value.from_untyped_value("name", Template("henk"))),
-            ScriptLine("add user {{name}} --is-superuser --is-active", 4,
+            ParsedLine("# add user henk", 1, VisibleComment(Template("add user henk"))),
+            ParsedLine("// adding user henk", 2, InvisibleComment("adding user henk")),
+            ParsedLine("$value name='henk'", 3, Value.from_untyped_value("name", Template("henk"))),
+            ParsedLine("add user {{name}} --is-superuser --is-active", 4,
                        Command(Template('add user {{name}} --is-superuser --is-active'))),
-            ScriptLine("$input text value: 'default value'", 5,
+            ParsedLine("$input text value: 'default value'", 5,
                        Input("value", InputType.TEXT, Template('default value'))),
-            ScriptLine("$wait Wait and relax", 6, Wait(Template("Wait and relax"))),
-            ScriptLine("", 7, Empty())
+            ParsedLine("$wait Wait and relax", 6, Wait(Template("Wait and relax"))),
+            ParsedLine("", 7, Empty())
         ]
 
         script_parser._parse_lines(state)


### PR DESCRIPTION
Introduce the [attrs library](https://www.attrs.org/en/stable/index.html) to avoid NamedTuples and dunder methods. Applied wherever it made sense.

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/system tested
- User documentation updated
- [x] Clean commits
- Added Feature/Fix to release notes
