### PR TITLE
Make the commander automation-friendly

### DIFF
--- a/mcmd/commands/config.py
+++ b/mcmd/commands/config.py
@@ -35,8 +35,9 @@ def add_arguments(config_subparsers):
                                                  mcmd config set non-interactive
                                                  mcmd config set interactive
     
-                                                 # Setting the default import action
-                                                 mcmd config set import-action add_update_existing
+                                                 # Setting the default import action interactively and with arguments
+                                                 mcmd config set import-action
+                                                 mcmd config set import-action --action add_update_existing
                                                """
                                            ))
     config_subparsers = config_.add_subparsers(dest='type', metavar='')
@@ -56,6 +57,9 @@ def add_arguments(config_subparsers):
     set_import_action = set_subparsers.add_parser('import-action',
                                                   help='set the default import action')
     set_import_action.set_defaults(func=config_set_import_action, write_to_history=False)
+    set_import_action.add_argument('--action',
+                                   help='the action to set',
+                                   choices=['add', 'add_update_existing', 'update'])
 
     set_non_interactive = set_subparsers.add_parser('non-interactive',
                                                     help='set non-interactive mode to true')
@@ -105,8 +109,12 @@ def config_set_host(args):
 # noinspection PyUnusedLocal
 @command
 def config_set_import_action(args):
-    options = ['add', 'add_update_existing', 'update']
-    action = ask.multi_choice('Choose the default import action:', options)
+    if args.action:
+        action = args.action
+    else:
+        options = ['add', 'add_update_existing', 'update']
+        action = ask.multi_choice('Choose the default import action:', options)
+
     io.start("Setting import action to {}".format(highlight(action)))
     config.set_import_action(action)
 

--- a/mcmd/commands/config.py
+++ b/mcmd/commands/config.py
@@ -1,3 +1,6 @@
+import textwrap
+from argparse import RawDescriptionHelpFormatter
+
 import mcmd.config.config as config
 from mcmd.commands._registry import arguments
 from mcmd.core.command import command, CommandType
@@ -11,49 +14,71 @@ from mcmd.io.io import highlight
 # =========
 
 @arguments('config', CommandType.META)
-def add_arguments(subparsers):
-    p_config = subparsers.add_parser('config',
-                                     help='change the configuration of MOLGENIS Commander')
-    p_config_subparsers = p_config.add_subparsers(dest='type', metavar='')
+def add_arguments(config_subparsers):
+    config_ = config_subparsers.add_parser('config',
+                                           help='change the configuration of MOLGENIS Commander',
+                                           formatter_class=RawDescriptionHelpFormatter,
+                                           description=textwrap.dedent(
+                                               """
+                                               Changes values in the configuration file.
+    
+                                               example usage:
+                                                 # Adding a host interactively or with arguments
+                                                 mcmd config add host
+                                                 mcmd config add host --url http://x --username admin --password admin
+    
+                                                 # Switching to another host interactively or with arguments
+                                                 mcmd config set host
+                                                 mcmd config set host http://localhost
+    
+                                                 # Enabling and disabling non-interactive mode
+                                                 mcmd config set non-interactive
+                                                 mcmd config set interactive
+    
+                                                 # Setting the default import action
+                                                 mcmd config set import-action add_update_existing
+                                               """
+                                           ))
+    config_subparsers = config_.add_subparsers(dest='type', metavar='')
 
-    p_config_set = p_config_subparsers.add_parser('set',
-                                                  help='set values in the configuration file')
+    set_ = config_subparsers.add_parser('set',
+                                        help='set values in the configuration file')
 
-    p_config_set_subparsers = p_config_set.add_subparsers(metavar='')
-    p_config_set_host = p_config_set_subparsers.add_parser('host',
-                                                           help='select a host')
-    p_config_set_host.set_defaults(func=config_set_host,
-                                   write_to_history=False)
-    p_config_set_host.add_argument('url',
-                                   nargs='?',
-                                   help='the URL of the host (Optional)')
+    set_subparsers = set_.add_subparsers(metavar='')
+    set_host = set_subparsers.add_parser('host',
+                                         help='select a host')
+    set_host.set_defaults(func=config_set_host,
+                          write_to_history=False)
+    set_host.add_argument('url',
+                          nargs='?',
+                          help='the URL of the host (Optional)')
 
-    p_config_set_import_action = p_config_set_subparsers.add_parser('import-action',
-                                                                    help='set the default import action')
-    p_config_set_import_action.set_defaults(func=config_set_import_action, write_to_history=False)
+    set_import_action = set_subparsers.add_parser('import-action',
+                                                  help='set the default import action')
+    set_import_action.set_defaults(func=config_set_import_action, write_to_history=False)
 
-    p_config_set_non_interactive = p_config_set_subparsers.add_parser('non-interactive',
-                                                                      help='set non-interactive mode to true')
-    p_config_set_non_interactive.set_defaults(func=config_set_non_interactive, write_to_history=False)
+    set_non_interactive = set_subparsers.add_parser('non-interactive',
+                                                    help='set non-interactive mode to true')
+    set_non_interactive.set_defaults(func=config_set_non_interactive, write_to_history=False)
 
-    p_config_set_interactive = p_config_set_subparsers.add_parser('interactive',
-                                                                  help='set non-interactive mode to false ')
-    p_config_set_interactive.set_defaults(func=config_set_interactive, write_to_history=False)
+    set_interactive = set_subparsers.add_parser('interactive',
+                                                help='set non-interactive mode to false ')
+    set_interactive.set_defaults(func=config_set_interactive, write_to_history=False)
 
-    p_config_add = p_config_subparsers.add_parser('add',
-                                                  help='add values in the configuration file')
-    p_config_add_subparsers = p_config_add.add_subparsers(metavar='')
+    add = config_subparsers.add_parser('add',
+                                       help='add values in the configuration file')
+    add_subparsers = add.add_subparsers(metavar='')
 
-    p_config_add_host = p_config_add_subparsers.add_parser('host',
-                                                           help='add a new host')
-    p_config_add_host.set_defaults(func=config_add_host,
-                                   write_to_history=False)
-    p_config_add_host.add_argument('--url',
-                                   help='the URL of the host')
-    p_config_add_host.add_argument('--username',
-                                   help='the username of the admin account')
-    p_config_add_host.add_argument('--password',
-                                   help='the password of the admin account')
+    add_host = add_subparsers.add_parser('host',
+                                         help='add a new host')
+    add_host.set_defaults(func=config_add_host,
+                          write_to_history=False)
+    add_host.add_argument('--url',
+                          help='the URL of the host')
+    add_host.add_argument('--username',
+                          help='the username of the admin account')
+    add_host.add_argument('--password',
+                          help='the password of the admin account')
 
 
 # =======

--- a/mcmd/config/config.py
+++ b/mcmd/config/config.py
@@ -11,7 +11,7 @@ from ruamel.yaml import YAML
 
 import mcmd.core.errors as errors
 
-_config = None
+_config = dict()
 _properties_file: Optional[Path] = None
 
 
@@ -84,6 +84,11 @@ def has_option(*args):
         return True
     except KeyError:
         return False
+
+
+def set_non_interactive(value: bool):
+    _config['settings']['non_interactive'] = value
+    _persist()
 
 
 def set_import_action(action):

--- a/mcmd/config/defaults.yaml
+++ b/mcmd/config/defaults.yaml
@@ -22,6 +22,9 @@ settings:
   # The default import action to use when importing a dataset.
   # Choose from: [add, add_update_existing, update]
   import_action: add_update_existing
+  # Set non-interactive mode to true when in pipelines or other automation. This will make a command fail
+  # if user input is needed instead of waiting endlessly.
+  non_interactive: false
 # Server configuration.
 host:
   # The server to interact with. Use `mcmd config set host` to change this field.

--- a/mcmd/io/ask.py
+++ b/mcmd/io/ask.py
@@ -1,14 +1,20 @@
 import questionary
 
+from mcmd.config import config
+from mcmd.core.errors import McmdError
 from mcmd.io import io
 
 
 def multi_choice(message, choices):
+    raise_if_non_interactive(message)
+
     question = questionary.select(message, choices=choices)
     return _ask(question)
 
 
 def checkbox(message, choices):
+    raise_if_non_interactive(message)
+
     checks = [{'name': choice, 'value': idx} for idx, choice in enumerate(choices)]
 
     question = questionary.checkbox(message, choices=checks)
@@ -18,6 +24,8 @@ def checkbox(message, choices):
 
 
 def input_(message, required=False):
+    raise_if_non_interactive(message)
+
     question = questionary.text(message)
 
     if required:
@@ -27,6 +35,8 @@ def input_(message, required=False):
 
 
 def password(message, required=False):
+    raise_if_non_interactive(message)
+
     question = questionary.password(message)
 
     if required:
@@ -36,6 +46,8 @@ def password(message, required=False):
 
 
 def confirm(message):
+    raise_if_non_interactive(message)
+
     question = questionary.confirm(message, default=False)
     return _ask(question)
 
@@ -61,3 +73,10 @@ def _validate_empty_list(answer):
 
 def _validate_empty_input(answer):
     return "This field can't be empty." if len(answer) == 0 else True
+
+
+def raise_if_non_interactive(message: str):
+    if config.get('settings', 'non_interactive'):
+        raise McmdError('User input required but running in non-interactive mode. Message: {}'.format(message),
+                        info="Please specify your command more precisely or switch to interactive mode with 'mcmd "
+                             "config set interactive'")

--- a/tests/integration/loader_mock.py
+++ b/tests/integration/loader_mock.py
@@ -21,6 +21,7 @@ host:
     password: {password}
 settings:
   import_action: add_update_existing
+  non_interactive: false
 """
 
 _url: str = None


### PR DESCRIPTION
Adds a `non-interactive` mode so the commander can be used in automated pipelines.

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/system tested
- [x] User documentation updated
- [x] Clean commits
- [x] Added Feature/Fix to release notes
